### PR TITLE
Trim -ipo option to build nlopt OK on Intel compilers

### DIFF
--- a/configure
+++ b/configure
@@ -3322,6 +3322,24 @@ $as_echo "$as_me: Need to download and build NLopt" >&6;}
    NLOPT_CXXFLAGS=$("${R_HOME}/bin/R" CMD config CXXFLAGS)
    NLOPT_CXXCPP=$("${R_HOME}/bin/R" CMD config CXXCPP)
 
+   ## If intel compiler then strip -ipo option as nlopt compilation
+   ## fails with it enabled
+   if test "${NLOPT_CC}" = "icc"; then
+     { $as_echo "$as_me:${as_lineno-$LINENO}: Intel CC detected - disabling ipo" >&5
+$as_echo "$as_me: Intel CC detected - disabling ipo" >&6;}
+     NLOPT_CFLAGS=$(echo "$NLOPT_CFLAGS" | sed 's/-ipo//')
+   fi
+   if test "${NLOPT_CPP}" = "icc"; then
+     { $as_echo "$as_me:${as_lineno-$LINENO}: Intel CPP detected - disabling ipo" >&5
+$as_echo "$as_me: Intel CPP detected - disabling ipo" >&6;}
+     NLOPT_CPPFLAGS=$(echo "$NLOPT_CPPFLAGS" | sed 's/-ipo//')
+   fi
+   if test "${NLOPT_CXX}" = "icpc"; then
+     { $as_echo "$as_me:${as_lineno-$LINENO}: Intel CXX detected - disabling ipo" >&5
+$as_echo "$as_me: Intel CXX detected - disabling ipo" >&6;}
+     NLOPT_CXXFLAGS=$(echo "$NLOPT_CXXFLAGS" | sed 's/-ipo//')
+   fi
+
    ## report values
    #echo "${NLOPT_CC} | ${NLOPT_CFLAGS} | ${NLOPT_CPPFLAGS} | ${NLOPT_CPPFLAGS} | ${NLOPT_CXX} | ${NLOPT_CXXFLAGS} | ${NLOPT_CXXCPP}"
 

--- a/configure.ac
+++ b/configure.ac
@@ -139,6 +139,21 @@ if test x"${nlopt_good}" = x"no"; then
    NLOPT_CXXFLAGS=$("${R_HOME}/bin/R" CMD config CXXFLAGS)
    NLOPT_CXXCPP=$("${R_HOME}/bin/R" CMD config CXXCPP)
 
+   ## If intel compiler then strip -ipo option as nlopt compilation
+   ## fails with it enabled
+   if test "${NLOPT_CC}" = "icc"; then
+     AC_MSG_NOTICE([Intel CC detected - disabling ipo])
+     NLOPT_CFLAGS=$(echo "$NLOPT_CFLAGS" | sed 's/-ipo//')
+   fi
+   if test "${NLOPT_CPP}" = "icc"; then
+     AC_MSG_NOTICE([Intel CPP detected - disabling ipo])
+     NLOPT_CPPFLAGS=$(echo "$NLOPT_CPPFLAGS" | sed 's/-ipo//')
+   fi
+   if test "${NLOPT_CXX}" = "icpc"; then
+     AC_MSG_NOTICE([Intel CXX detected - disabling ipo])
+     NLOPT_CXXFLAGS=$(echo "$NLOPT_CXXFLAGS" | sed 's/-ipo//')
+   fi
+
    ## report values
    #echo "${NLOPT_CC} | ${NLOPT_CFLAGS} | ${NLOPT_CPPFLAGS} | ${NLOPT_CPPFLAGS} | ${NLOPT_CXX} | ${NLOPT_CXXFLAGS} | ${NLOPT_CXXCPP}"
 


### PR DESCRIPTION
We build R for our HPC cluster using the Intel 2015 compiler suite, with various optimization options.

nloptr cannot be installed in this situation, as the nlopt library fails to build if the '-ipo' compiler option is enabled.

This change to `configure.ac` will disable `-ipo` for the nlopt library compilation, permitting nloptr to be installed with this Intel compiler configuration.

Will investigate upstream issue in nlopt, but proposing this PR here since nloptr is pinning a specific version of nlopt to install, and this workaround allows our users to use nloptr on our systems, while an upstream fix is more difficult to implement at present.
