### PR TITLE
Download nlopt from GitHub

### DIFF
--- a/configure
+++ b/configure
@@ -3293,7 +3293,7 @@ $as_echo "$as_me: Need to download and build NLopt" >&6;}
 
    ## define NLopt file and download URL
    NLOPT_TGZ="nlopt-${NLOPT_VERSION}.tar.gz"
-   NLOPT_URL="http://ab-initio.mit.edu/nlopt/${NLOPT_TGZ}"
+   NLOPT_URL="https://github.com/stevengj/nlopt/archive/${NLOPT_TGZ}"
 
    ## C Compiler options
    NLOPTR_CFLAGS=
@@ -3326,13 +3326,15 @@ $as_echo "$as_me: Need to download and build NLopt" >&6;}
    #echo "${NLOPT_CC} | ${NLOPT_CFLAGS} | ${NLOPT_CPPFLAGS} | ${NLOPT_CPPFLAGS} | ${NLOPT_CXX} | ${NLOPT_CXXFLAGS} | ${NLOPT_CXXCPP}"
 
    ## Download NLopt source code
-   ## curl -O http://ab-initio.mit.edu/nlopt/nlopt-${NLOPT_VERSION}.tar.gz
-   $("${R_HOME}/bin/Rscript" ${r_args} -e "download.file(url='${NLOPT_URL}', destfile='${NLOPT_TGZ}')")
+   ## curl -OL https://github.com/stevengj/nlopt/archive/nlopt-${NLOPT_VERSION}.tar.gz
+   $("${R_HOME}/bin/Rscript" ${r_args} -e "download.file(url='${NLOPT_URL}', destfile='${NLOPT_TGZ}', extra='-L')")
 
    ## Extract NLopt source code and remove .tar.gz
    ## tar -xzvf nlopt-${NLOPT_VERSION}.tar.gz
    $("${R_HOME}/bin/Rscript" ${r_args} -e "untar(tarfile='${NLOPT_TGZ}')")
    $(rm -rf ${NLOPT_TGZ})
+
+   $(mv nlopt-nlopt-${NLOPT_VERSION} nlopt-${NLOPT_VERSION})
 
    ## Compile NLopt source code and clean up
    ## --prefix="`pwd`", which is the directory we want to
@@ -3343,7 +3345,8 @@ $as_echo "$as_me: Starting to install library to $(pwd)/nlopt-${NLOPT_VERSION}" 
         ed -s isres/isres.c <<< $'H\n,s/sqrt(/sqrt((double) /g\nw'; \
         ed -s util/qsort_r.c <<< $'H\n1i\nextern "C" {\n.\nw'; \
         ed -s util/qsort_r.c <<< $'H\n$a\n}\n.\nw' ; \
-        ./configure --prefix="$(pwd)" --enable-shared --enable-static --without-octave \
+        sh autogen.sh --no-configure; \
+        ./configure --prefix="$(pwd)" --enable-maintainer-mode --enable-shared --enable-static --without-octave \
                     --without-matlab --without-guile --without-python --with-cxx \
                     CC="${NLOPT_CC}" CFLAGS="${NLOPT_CFLAGS}" CPP="${NLOPT_CPP}" \
                     CPPFLAGS="${NLOPT_CPPFLAGS}" CXX="${NLOPT_CXX}" \

--- a/configure.ac
+++ b/configure.ac
@@ -110,7 +110,7 @@ if test x"${nlopt_good}" = x"no"; then
 
    ## define NLopt file and download URL
    NLOPT_TGZ="nlopt-${NLOPT_VERSION}.tar.gz"
-   NLOPT_URL="http://ab-initio.mit.edu/nlopt/${NLOPT_TGZ}"
+   NLOPT_URL="https://github.com/stevengj/nlopt/archive/${NLOPT_TGZ}"
 
    ## C Compiler options    
    NLOPTR_CFLAGS= 
@@ -143,13 +143,15 @@ if test x"${nlopt_good}" = x"no"; then
    #echo "${NLOPT_CC} | ${NLOPT_CFLAGS} | ${NLOPT_CPPFLAGS} | ${NLOPT_CPPFLAGS} | ${NLOPT_CXX} | ${NLOPT_CXXFLAGS} | ${NLOPT_CXXCPP}"
 
    ## Download NLopt source code
-   ## curl -O http://ab-initio.mit.edu/nlopt/nlopt-${NLOPT_VERSION}.tar.gz
-   $("${R_HOME}/bin/Rscript" ${r_args} -e "download.file(url='${NLOPT_URL}', destfile='${NLOPT_TGZ}')")
+   ## curl -OL https://github.com/stevengj/nlopt/archive/nlopt-${NLOPT_VERSION}.tar.gz
+   $("${R_HOME}/bin/Rscript" ${r_args} -e "download.file(url='${NLOPT_URL}', destfile='${NLOPT_TGZ}', extra='-L')")
 
    ## Extract NLopt source code and remove .tar.gz
    ## tar -xzvf nlopt-${NLOPT_VERSION}.tar.gz
    $("${R_HOME}/bin/Rscript" ${r_args} -e "untar(tarfile='${NLOPT_TGZ}')")
    $(rm -rf ${NLOPT_TGZ})
+
+   $(mv nlopt-nlopt-${NLOPT_VERSION} nlopt-${NLOPT_VERSION})
 
    ## Compile NLopt source code and clean up
    ## --prefix="`pwd`", which is the directory we want to
@@ -159,7 +161,8 @@ if test x"${nlopt_good}" = x"no"; then
         ed -s isres/isres.c <<< $'H\n,s/sqrt(/sqrt((double) /g\nw'; \
         ed -s util/qsort_r.c <<< $'H\n1i\nextern "C" {\n.\nw'; \
         ed -s util/qsort_r.c <<< $'H\n$a\n}\n.\nw' ; \
-        ./configure --prefix="$(pwd)" --enable-shared --enable-static --without-octave \
+        sh autogen.sh --no-configure; \
+        ./configure --prefix="$(pwd)" --enable-maintainer-mode --enable-shared --enable-static --without-octave \
                     --without-matlab --without-guile --without-python --with-cxx \
                     CC="${NLOPT_CC}" CFLAGS="${NLOPT_CFLAGS}" CPP="${NLOPT_CPP}" \
                     CPPFLAGS="${NLOPT_CPPFLAGS}" CXX="${NLOPT_CXX}" \


### PR DESCRIPTION
Because ab-initio.mit.edu appears to be highly unreliable

- Need to follow redirects when downloading
- GitHub tarfile contents are prefixed with an extra "nlopt-", move the directory after extracting
- Need to run autogen.sh before configure
- Need to enable maintainer mode when configuring