### PR TITLE
Add BOBYQA solver for method "auglag"

### DIFF
--- a/R/auglag.R
+++ b/R/auglag.R
@@ -19,7 +19,7 @@ function(x0, fn, gr = NULL, lower = NULL, upper = NULL,
     }
 
     localsolver <- toupper(localsolver)
-    if (localsolver %in% c("COBYLA")) {   # derivative-free
+    if (localsolver %in% c("COBYLA", "BOBYQA")) {   # derivative-free
         dfree <- TRUE
         gsolver <- "NLOPT_LN_AUGLAG"
         lsolver <- paste("NLOPT_LN_", localsolver, sep = "")


### PR DESCRIPTION
BOBYQA mentioned as a potential local solver in line #31, but not implemented.
Reason for requesting the addition is that COBYLA sometimes hangs (https://github.com/stevengj/nlopt/issues/118). This seems to be an issue with nlopt itself.