### PR TITLE
Fix parameter description for nloptr.R

### DIFF
--- a/R/nloptr.R
+++ b/R/nloptr.R
@@ -78,13 +78,13 @@
 #' controls.
 #' @param eval_g_ineq function to evaluate (non-)linear inequality constraints
 #' that should hold in the solution.  It can also return gradient information
-#' at the same time in a list with elements "objective" and "jacobian" (see
+#' at the same time in a list with elements "constraints" and "jacobian" (see
 #' below for an example).
 #' @param eval_jac_g_ineq function to evaluate the jacobian of the (non-)linear
 #' inequality constraints that should hold in the solution.
 #' @param eval_g_eq function to evaluate (non-)linear equality constraints that
 #' should hold in the solution.  It can also return gradient information at the
-#' same time in a list with elements "objective" and "jacobian" (see below for
+#' same time in a list with elements "constraints" and "jacobian" (see below for
 #' an example).
 #' @param eval_jac_g_eq function to evaluate the jacobian of the (non-)linear
 #' equality constraints that should hold in the solution.

--- a/man/nloptr.Rd
+++ b/man/nloptr.Rd
@@ -28,7 +28,7 @@ controls.}
 
 \item{eval_g_ineq}{function to evaluate (non-)linear inequality constraints
 that should hold in the solution.  It can also return gradient information
-at the same time in a list with elements "objective" and "jacobian" (see
+at the same time in a list with elements "constraints" and "jacobian" (see
 below for an example).}
 
 \item{eval_jac_g_ineq}{function to evaluate the jacobian of the (non-)linear
@@ -36,7 +36,7 @@ inequality constraints that should hold in the solution.}
 
 \item{eval_g_eq}{function to evaluate (non-)linear equality constraints that
 should hold in the solution.  It can also return gradient information at the
-same time in a list with elements "objective" and "jacobian" (see below for
+same time in a list with elements "constraints" and "jacobian" (see below for
 an example).}
 
 \item{eval_jac_g_eq}{function to evaluate the jacobian of the (non-)linear


### PR DESCRIPTION
Fixes #3 - parameter description for `eval_g_ineq` and `eval_g_eq` now uses correct required element names.