### PR TITLE
Enable evolution algorithm (implemented in nlopt already)

### DIFF
--- a/R/is.nloptr.R
+++ b/R/is.nloptr.R
@@ -70,7 +70,7 @@ is.nloptr <- function( x ) {
                           "NLOPT_LN_NEWUOA", "NLOPT_LN_NEWUOA_BOUND", "NLOPT_LN_NELDERMEAD",
                           "NLOPT_LN_SBPLX", "NLOPT_LN_AUGLAG", "NLOPT_LD_AUGLAG",
                           "NLOPT_LN_AUGLAG_EQ", "NLOPT_LD_AUGLAG_EQ", "NLOPT_LN_BOBYQA",
-                          "NLOPT_GN_ISRES" )
+                          "NLOPT_GN_ISRES", "NLOPT_GN_ESCH" )
 
     # check if an existing algorithm was supplied
     if ( !( x$options$algorithm %in% list_algorithms ) ) {

--- a/src/nloptr.c
+++ b/src/nloptr.c
@@ -185,6 +185,9 @@ nlopt_algorithm getAlgorithmCode( const char *algorithm_str ) {
     }
     else if ( strcmp( algorithm_str, "NLOPT_GN_ISRES" ) == 0 ) {
         algorithm = NLOPT_GN_ISRES;
+    } 
+    else if ( strcmp( algorithm_str, "NLOPT_GN_ESCH" ) == 0 ) { 
+        algorithm = NLOPT_GN_ESCH;
     }
     else {
         // unknown algorithm code


### PR DESCRIPTION
The evolution algorithm has been implemented in `nlopt` but wasn't enabled in `nloptr`. This patch fixes the issue that setting `algorithm='NLOPT_GN_ESCH'` throws an error.