### PR TITLE
Fix out bashisms in configure scripts

### DIFF
--- a/configure
+++ b/configure
@@ -2981,8 +2981,8 @@ nlopt_libs=""
 
 ## also use pkg-config to check for NLopt
 ##
-if test x"${nlopt_libs}" == x""; then
-    if test x"${PKGCONFIG}" == x"yes"; then
+if test x"${nlopt_libs}" = x""; then
+    if test x"${PKGCONFIG}" = x"yes"; then
         ## check via pkg-config for nlopt
         if pkg-config --exists nlopt; then
             ## obtain cflags and obtain libs
@@ -3279,7 +3279,7 @@ fi
 if test x"${nlopt_good}" = x"yes"; then
     { $as_echo "$as_me:${as_lineno-$LINENO}: Now testing for NLopt version 2.4.0 or greater." >&5
 $as_echo "$as_me: Now testing for NLopt version 2.4.0 or greater." >&6;}
-    if test x"${PKGCONFIG}" == x"yes"; then
+    if test x"${PKGCONFIG}" = x"yes"; then
         ## check via pkg-config for version number of nlopt
         if pkg-config --exists nlopt; then
             ## obtain version number

--- a/configure.ac
+++ b/configure.ac
@@ -65,8 +65,8 @@ nlopt_libs=""
 
 ## also use pkg-config to check for NLopt
 ##
-if test x"${nlopt_libs}" == x""; then
-    if test x"${PKGCONFIG}" == x"yes"; then
+if test x"${nlopt_libs}" = x""; then
+    if test x"${PKGCONFIG}" = x"yes"; then
         ## check via pkg-config for nlopt
         if pkg-config --exists nlopt; then
             ## obtain cflags and obtain libs
@@ -96,7 +96,7 @@ AC_CHECK_HEADER([$nlopt_header],
 # version, does not work.
 if test x"${nlopt_good}" = x"yes"; then
     AC_MSG_NOTICE([Now testing for NLopt version 2.4.0 or greater.])
-    if test x"${PKGCONFIG}" == x"yes"; then
+    if test x"${PKGCONFIG}" = x"yes"; then
         ## check via pkg-config for version number of nlopt
         if pkg-config --exists nlopt; then
             ## obtain version number


### PR DESCRIPTION
It was found in #82 that `configure.ac` template contains bashisms which weren't identified by CRAN utils in the past. They screwed usage of this R package with shells other than `bash`, e. g. `dash`. Now it should be fine