### PR TITLE
Build from source if system nlopt too old, small DESCRIPTION edit

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,10 +32,9 @@ Description:
     online as well as original implementations of various other algorithms.
     See <https://nlopt.readthedocs.io/en/latest/NLopt_Algorithms/> for more
     information on the available algorithms. Building from included sources 
-    requires CMake which will be searched for on your PATH. If it cannot 
-    find one, it will prompt you to install it and provide hints on how to 
-    do so for usual operating systems. On Linux, if a system build of NLopt 
-    is found, it is used. On Windows, NLopt is obtained through rwinlib.
+    requires CMake. On Linux and macOS, if a system build of NLopt (2.7.0 or
+    later) is found, it is used; other. On Windows, NLopt is obtained through
+    rwinlib.
 License: LGPL (>= 3)
 SystemRequirements: cmake (needed when building from source, i.e. on macOS or 
     on Linux if no system build is found)

--- a/configure
+++ b/configure
@@ -2775,9 +2775,8 @@ $as_echo_n "checking for pkg-config checking NLopt version... " >&6; }
 $as_echo ">= 2.7.0" >&6; }
         need_to_build="no"
     else
-        { $as_echo "$as_me:${as_lineno-$LINENO}: result: insufficient" >&5
-$as_echo "insufficient" >&6; }
-        as_fn_error $? "NLopt 2.7.0 or later is required." "$LINENO" 5
+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: insufficient: NLopt 2.7.0 or later is preferred." >&5
+$as_echo "insufficient: NLopt 2.7.0 or later is preferred." >&6; }
     fi
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -58,8 +58,7 @@ if test x"${have_pkg_config}" != x"no"; then
         AC_MSG_RESULT([>= 2.7.0])
         need_to_build="no"
     else
-        AC_MSG_RESULT([insufficient])
-        AC_MSG_ERROR([NLopt 2.7.0 or later is required.])
+        AC_MSG_RESULT([insufficient: NLopt 2.7.0 or later is preferred.])
     fi
 fi
 


### PR DESCRIPTION
This PR changes `configure{,.ac}` to only _message_ (but not _error_) if a system NLopt was found, but is older than 2.7.0.  That was a good catch by CRAN.

The `DESCRIPTION` was also edited to note the minimum version we prefer, and shortened it a little. (There is no 'prompt' so I took the part that usually goes into SystemRequirements out.)