### PR TITLE
End configuration sooner and louder if cmake missing when needed

### DIFF
--- a/configure
+++ b/configure
@@ -2828,7 +2828,7 @@ fi
        ## invoked for the side-effect of the cmake installation hints
        src/scripts/cmake_config.sh
        ## also error to end configure here
-       as_fn_error $? "Could not fine 'cmake'." "$LINENO" 5
+       as_fn_error $? "Could not find 'cmake'." "$LINENO" 5
     fi
     ## 'uname -m' on M1 give x86_64 which is ... not helping
     machine=`"${R_HOME}/bin/Rscript" -e 'cat(Sys.info()["machine"])'`

--- a/configure
+++ b/configure
@@ -584,6 +584,7 @@ PACKAGE_URL=''
 ac_subst_vars='LTLIBOBJS
 LIBOBJS
 NLOPT_CPPFLAGS
+have_cmake
 NLOPT_LIBS
 NLOPT_INCLUDE
 have_pkg_config
@@ -2782,6 +2783,53 @@ fi
 
 ## So do we need to build
 if test x"${need_to_build}" != x"no"; then
+    # Extract the first word of "cmake", so it can be a program name with args.
+set dummy cmake; ac_word=$2
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_path_have_cmake+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  case $have_cmake in
+  [\\/]* | ?:[\\/]*)
+  ac_cv_path_have_cmake="$have_cmake" # Let the user override the test with a path.
+  ;;
+  *)
+  as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+for as_dir in $PATH
+do
+  IFS=$as_save_IFS
+  test -z "$as_dir" && as_dir=.
+    for ac_exec_ext in '' $ac_executable_extensions; do
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
+    ac_cv_path_have_cmake="$as_dir/$ac_word$ac_exec_ext"
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
+    break 2
+  fi
+done
+  done
+IFS=$as_save_IFS
+
+  test -z "$ac_cv_path_have_cmake" && ac_cv_path_have_cmake="no"
+  ;;
+esac
+fi
+have_cmake=$ac_cv_path_have_cmake
+if test -n "$have_cmake"; then
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $have_cmake" >&5
+$as_echo "$have_cmake" >&6; }
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+
+
+    if test x"${have_cmake}" == x"no"; then
+       ## invoked for the side-effect of the cmake installation hints
+       src/scripts/cmake_config.sh
+       ## also error to end configure here
+       as_fn_error $? "Could not fine 'cmake'." "$LINENO" 5
+    fi
     ## 'uname -m' on M1 give x86_64 which is ... not helping
     machine=`"${R_HOME}/bin/Rscript" -e 'cat(Sys.info()["machine"])'`
     { $as_echo "$as_me:${as_lineno-$LINENO}: result: using NLopt via local cmake build on ${machine} " >&5

--- a/configure.ac
+++ b/configure.ac
@@ -64,6 +64,13 @@ fi
 
 ## So do we need to build
 if test x"${need_to_build}" != x"no"; then
+    AC_PATH_PROG(have_cmake, cmake, no)
+    if test x"${have_cmake}" == x"no"; then
+       ## invoked for the side-effect of the cmake installation hints
+       src/scripts/cmake_config.sh
+       ## also error to end configure here
+       AC_MSG_ERROR([Could not fine 'cmake'.])
+    fi
     ## 'uname -m' on M1 give x86_64 which is ... not helping
     machine=`"${R_HOME}/bin/Rscript" -e 'cat(Sys.info()[["machine"]])'`
     AC_MSG_RESULT([using NLopt via local cmake build on ${machine} ])

--- a/configure.ac
+++ b/configure.ac
@@ -69,7 +69,7 @@ if test x"${need_to_build}" != x"no"; then
        ## invoked for the side-effect of the cmake installation hints
        src/scripts/cmake_config.sh
        ## also error to end configure here
-       AC_MSG_ERROR([Could not fine 'cmake'.])
+       AC_MSG_ERROR([Could not find 'cmake'.])
     fi
     ## 'uname -m' on M1 give x86_64 which is ... not helping
     machine=`"${R_HOME}/bin/Rscript" -e 'cat(Sys.info()[["machine"]])'`


### PR DESCRIPTION
We had some reports where users didn't really realize they were missing `cmake`.  I realized that I can (and maybe "should", hence this PR) test for that and have `configure` stop with the clear message from your shell script.

On empty R docker container (without `cmake` or `nlopt`) we now get:

```sh
edd@rob:~/git/nloptr(master)$ docker run --rm -ti -v $PWD:/mnt -w /work r-base bash
root@2b5065467a3a:/work# ./configure 
checking whether the C++ compiler works... yes
checking for C++ compiler default output file name... a.out
checking for suffix of executables... 
checking whether we are cross compiling... no
checking for suffix of object files... o
checking whether we are using the GNU C++ compiler... yes
checking whether g++ -std=gnu++14 accepts -g... yes
checking how to run the C++ preprocessor... g++ -std=gnu++14 -E
checking whether we are using the GNU C++ compiler... (cached) yes
checking whether g++ -std=gnu++14 accepts -g... (cached) yes
checking for pkg-config... /usr/bin/pkg-config
checking if pkg-config knows NLopt... no
checking for cmake... no

------------------ CMAKE NOT FOUND --------------------

CMake was not found on the PATH. Please install CMake:

 - yum install cmake          (Fedora/CentOS; inside a terminal)
 - apt install cmake          (Debian/Ubuntu; inside a terminal).
 - pacman -S cmake            (Arch Linux; inside a terminal).
 - brew install cmake         (MacOS; inside a terminal with Homebrew)
 - port install cmake         (MacOS; inside a terminal with MacPorts)

Alternatively install CMake from: <https://cmake.org/>

-------------------------------------------------------

configure: error: Could not fine 'cmake'.
root@2b5065467a3a:/work# 
```

Feel free to discard if you would rather address this differently what it occured to me that this may help.