### PR TITLE
Added an 'any()' in R/is.nloptr.R

### DIFF
--- a/R/is.nloptr.R
+++ b/R/is.nloptr.R
@@ -95,7 +95,7 @@ is.nloptr <- function( x ) {
         }
 
     } else {
-        if ( is.na( f0 ) ) { stop('objective in x0 returns NA') }
+        if (any( is.na( f0 ) )) { stop('objective in x0 returns NA') }
 
         # check whether algorihtm needs a derivative
         if ( x$options$algorithm %in% list_algorithmsD ) {


### PR DESCRIPTION
in order to fix error 'condition has length > 1', this changed from a warning to an error in R-4.2.0 and would not allow the code to run through any more.