### PR TITLE
Ensure seven digits are printed when comparing to seven (closes #140)

### DIFF
--- a/inst/tinytest/test-check.derivatives.R
+++ b/inst/tinytest/test-check.derivatives.R
@@ -10,6 +10,8 @@
 # Changelog:
 #
 
+options(digits=7)
+
 f <- function(x, a) {sum((x - a) ^ 2)}
 f_grad <- function(x, a) {2 * (x - a)}
 

--- a/inst/tinytest/test-nloptr.R
+++ b/inst/tinytest/test-nloptr.R
@@ -15,6 +15,8 @@
 # weird-looking test. See
 # https://nlopt.readthedocs.io/en/latest/NLopt_Reference/#stopping-criteria
 
+options(digits=7)
+
 tol <- sqrt(.Machine$double.eps)
 
 ########################## Tests for nloptr.R ##################################

--- a/inst/tinytest/test-print.nloptr.R
+++ b/inst/tinytest/test-print.nloptr.R
@@ -11,6 +11,8 @@
 #   2023-08-23: Convert _output to _stdout for tinytest
 #
 
+options(digits=7)
+
 x0 <- c(3, 3)
 fn <- function(x) (x[1] - 1) ^ 2 + (x[2] - 1) ^ 2
 


### PR DESCRIPTION
Adding `options(digits=7)` to three test files that rely on it ensure the test passses when it would otherwise fail under a different setting.