### PR TITLE
Possible fix of directL Random Issue

### DIFF
--- a/R/direct.R
+++ b/R/direct.R
@@ -73,7 +73,6 @@
 #'
 #' ### Minimize the Hartmann6 function
 #' hartmann6 <- function(x) {
-#'   n <- length(x)
 #'   a <- c(1.0, 1.2, 3.0, 3.2)
 #'   A <- matrix(c(10.0,  0.05, 3.0, 17.0,
 #'          3.0, 10.0,  3.5,  8.0,
@@ -87,17 +86,17 @@
 #'          .0124,.3736,.2883,.5743,
 #'          .8283,.1004,.3047,.1091,
 #'          .5886,.9991,.6650,.0381), nrow=4, ncol=6)
-#'   fun <- 0.0
+#'   fun <- 0
 #'   for (i in 1:4) {
-#'     fun <- fun - a[i] * exp(-sum(A[i,]*(x-B[i,])^2))
+#'     fun <- fun - a[i] * exp(-sum(A[i,] * (x - B[i,]) ^ 2))
 #'   }
-#'   return(fun)
+#'   fun
 #' }
-#' S <- directL(hartmann6, rep(0,6), rep(1,6),
-#'        nl.info = TRUE, control=list(xtol_rel=1e-8, maxeval=1000))
-#' ## Number of Iterations....: 500
+#' S <- directL(hartmann6, rep(0, 6), rep(1, 6),
+#'        nl.info = TRUE, control = list(xtol_rel = 1e-8, maxeval = 1000))
+#' ## Number of Iterations....: 1000
 #' ## Termination conditions:  stopval: -Inf
-#' ##   xtol_rel: 1e-08,  maxeval: 500,  ftol_rel: 0,  ftol_abs: 0
+#' ##   xtol_rel: 1e-08,  maxeval: 1000,  ftol_rel: 0,  ftol_abs: 0
 #' ## Number of inequality constraints:  0
 #' ## Number of equality constraints:  0
 #' ## Current value of objective function:  -3.32236800687327

--- a/inst/tinytest/test-wrapper-direct.R
+++ b/inst/tinytest/test-wrapper-direct.R
@@ -15,7 +15,7 @@
 # the randomization at the C level. For now, need to pass this tolerance for it
 # to work.
 # (AA: 2026-02-06)
-tol <- 1e-4
+tol <- 1e-6
 
 ## Functions for DIRECT and DIRECT_L
 hartmann6 <- function(x) {
@@ -124,6 +124,13 @@ expect_identical(directLTest$message, directLControl$message)
 # Test DIRECTL algorithm Randomized: TRUE Original: FALSE
 ctl <- list(xtol_rel = 1e-8, maxeval = 10000L)
 directLTest <- directL(hartmann6, lb, ub, randomized = TRUE, control = ctl)
+
+directLControl <- nloptr(x0 = x0,
+                         eval_f = hartmann6,
+                         lb = lb,
+                         ub = ub,
+                         opts = list(algorithm = "NLOPT_GN_DIRECT_L_RAND",
+                                     xtol_rel = 1e-8, maxeval = 10000L))
 
 directLControl <- nloptr(x0 = x0,
                          eval_f = hartmann6,

--- a/inst/tinytest/test-wrapper-direct.R
+++ b/inst/tinytest/test-wrapper-direct.R
@@ -121,34 +121,8 @@ expect_identical(directLTest$iter, directLControl$iterations)
 expect_identical(directLTest$convergence, directLControl$status)
 expect_identical(directLTest$message, directLControl$message)
 
-# Test DIRECTL algorithm Randomized: TRUE Original: FALSE
-ctl <- list(xtol_rel = 1e-8, maxeval = 10000L)
-directLTest <- directL(hartmann6, lb, ub, randomized = TRUE, control = ctl)
-
-directLControl <- nloptr(x0 = x0,
-                         eval_f = hartmann6,
-                         lb = lb,
-                         ub = ub,
-                         opts = list(algorithm = "NLOPT_GN_DIRECT_L_RAND",
-                                     xtol_rel = 1e-8, maxeval = 10000L))
-
-directLControl <- nloptr(x0 = x0,
-                         eval_f = hartmann6,
-                         lb = lb,
-                         ub = ub,
-                         opts = list(algorithm = "NLOPT_GN_DIRECT_L_RAND",
-                                     xtol_rel = 1e-8, maxeval = 10000L))
-
-# May have something to do with the randomization. Setting seeds before the
-# calls does not help with check_identical
-# (AA: 2023-02-06)
-expect_equal(directLTest$par, directLControl$solution, tolerance = tol)
-expect_equal(directLTest$value, directLControl$objective, tolerance = tol)
-expect_identical(directLTest$iter, directLControl$iterations)
-expect_identical(directLTest$convergence, directLControl$status)
-expect_identical(directLTest$message, directLControl$message)
-
 # Test DIRECTL algorithm Original: TRUE
+ctl <- list(xtol_rel = 1e-8, maxeval = 10000L)
 directLTest <- directL(hartmann6, lb, ub, randomized = TRUE, original = TRUE,
                        control = ctl)
 
@@ -164,3 +138,25 @@ expect_identical(directLTest$value, directLControl$objective)
 expect_identical(directLTest$iter, directLControl$iterations)
 expect_identical(directLTest$convergence, directLControl$status)
 expect_identical(directLTest$message, directLControl$message)
+
+# Test DIRECTL algorithm Randomized: TRUE Original: FALSE
+ctl <- list(xtol_rel = 1e-8, maxeval = 50000L)
+
+directLTest <- directL(hartmann6, lb, ub, randomized = TRUE, control = ctl)
+
+directLControl <- nloptr(x0 = x0,
+                         eval_f = hartmann6,
+                         lb = lb,
+                         ub = ub,
+                         opts = list(algorithm = "NLOPT_GN_DIRECT_L_RAND",
+                                     xtol_rel = 1e-8, maxeval = 50000L))
+
+# May have something to do with the randomization. Setting seeds before the
+# calls does not help with check_identical
+# (AA: 2023-02-06)
+expect_equal(directLTest$par, directLControl$solution, tolerance = tol)
+expect_equal(directLTest$value, directLControl$objective, tolerance = tol)
+expect_identical(directLTest$iter, directLControl$iterations)
+expect_identical(directLTest$convergence, directLControl$status)
+expect_identical(directLTest$message, directLControl$message)
+

--- a/inst/tinytest/test-wrapper-direct.R
+++ b/inst/tinytest/test-wrapper-direct.R
@@ -15,7 +15,7 @@
 # the randomization at the C level. For now, need to pass this tolerance for it
 # to work.
 # (AA: 2026-02-06)
-tol <- 1e-6
+tol <- 1e-4
 
 ## Functions for DIRECT and DIRECT_L
 hartmann6 <- function(x) {

--- a/man/direct.Rd
+++ b/man/direct.Rd
@@ -84,7 +84,6 @@ The DIRECT_L algorithm should be tried first.
 
 ### Minimize the Hartmann6 function
 hartmann6 <- function(x) {
-  n <- length(x)
   a <- c(1.0, 1.2, 3.0, 3.2)
   A <- matrix(c(10.0,  0.05, 3.0, 17.0,
          3.0, 10.0,  3.5,  8.0,
@@ -98,17 +97,17 @@ hartmann6 <- function(x) {
          .0124,.3736,.2883,.5743,
          .8283,.1004,.3047,.1091,
          .5886,.9991,.6650,.0381), nrow=4, ncol=6)
-  fun <- 0.0
+  fun <- 0
   for (i in 1:4) {
-    fun <- fun - a[i] * exp(-sum(A[i,]*(x-B[i,])^2))
+    fun <- fun - a[i] * exp(-sum(A[i,] * (x - B[i,]) ^ 2))
   }
-  return(fun)
+  fun
 }
-S <- directL(hartmann6, rep(0,6), rep(1,6),
-       nl.info = TRUE, control=list(xtol_rel=1e-8, maxeval=1000))
-## Number of Iterations....: 500
+S <- directL(hartmann6, rep(0, 6), rep(1, 6),
+       nl.info = TRUE, control = list(xtol_rel = 1e-8, maxeval = 1000))
+## Number of Iterations....: 1000
 ## Termination conditions:  stopval: -Inf
-##   xtol_rel: 1e-08,  maxeval: 500,  ftol_rel: 0,  ftol_abs: 0
+##   xtol_rel: 1e-08,  maxeval: 1000,  ftol_rel: 0,  ftol_abs: 0
 ## Number of inequality constraints:  0
 ## Number of equality constraints:  0
 ## Current value of objective function:  -3.32236800687327


### PR DESCRIPTION
Hello, @astamm. 

This is bizarre. It passes all tests on my machine and with Github actions. However, manually running the tests *sometimes* gave an error and sometimes not. I increased the iterations from 10K to 50K. Then it passed my manually running the tests as well. My intuition is that there are local minima close to each other, and 10K isn't enough to go from the weaker one to the stronger one, sometimes. Maybe 50K is enough. Otherwise, I would suggest eliminating this test since we know the algorithm works, just that it may be "picky". Perhaps there is something deeper in the `nlopt` code itself. I did unzip the tar and look through it briefly, but nothing stood out to me. A deeper dive may be warranted if this continues, which is weird.