### PR TITLE
Add library(nloptr) to make test files self-sufficient (closes #139)

### DIFF
--- a/inst/tinytest/test-banana-global.R
+++ b/inst/tinytest/test-banana-global.R
@@ -15,6 +15,8 @@
 #   2019-12-12: Corrected warnings and using updated testtthat framework (AA)
 #   2023-02-07: Remove wrapping tests in "test_that" to reduce duplication. (AA)
 
+library(nloptr)
+
 tol <- sqrt(.Machine$double.eps)
 # Test Rosenbrock Banana optimization with global optimizer NLOPT_GD_MLSL.
 

--- a/inst/tinytest/test-banana.R
+++ b/inst/tinytest/test-banana.R
@@ -15,6 +15,8 @@
 #   2019-12-12: Corrected warnings and using updated testtthat framework (AA)
 #   2023-02-07: Remove wrapping tests in "test_that" to reduce duplication. (AA)
 
+library(nloptr)
+
 tol <- sqrt(.Machine$double.eps)
 # Test Rosenbrock Banana optimization with objective and gradient in separate
 # functions.

--- a/inst/tinytest/test-check.derivatives.R
+++ b/inst/tinytest/test-check.derivatives.R
@@ -10,6 +10,7 @@
 # Changelog:
 #
 
+library(nloptr)
 options(digits=7)
 
 f <- function(x, a) {sum((x - a) ^ 2)}

--- a/inst/tinytest/test-derivative-checker.R
+++ b/inst/tinytest/test-derivative-checker.R
@@ -17,6 +17,8 @@
 #   2023-08-23: Prefix finite.diff with nloptr::: as part of move to tinytest
 #
 
+library(nloptr)
+
 # Test derivative checker.
 
 tol <- 1e-7

--- a/inst/tinytest/test-example.R
+++ b/inst/tinytest/test-example.R
@@ -27,6 +27,8 @@
 #   2019-12-12: Corrected warnings and using updated testtthat framework (AA)
 #   2023-02-07: Remove wrapping tests in "test_that" to reduce duplication. (AA)
 
+library(nloptr)
+
 tol <- sqrt(.Machine$double.eps)
 
 # objective function

--- a/inst/tinytest/test-gradients.R
+++ b/inst/tinytest/test-gradients.R
@@ -10,6 +10,8 @@
 # Changelog:
 #
 
+library(nloptr)
+
 tol <- sqrt(.Machine$double.eps)
 
 fn1 <- function(x) sum(x ^ 2)

--- a/inst/tinytest/test-hs023.R
+++ b/inst/tinytest/test-hs023.R
@@ -38,6 +38,8 @@
 #   2023-02-07: Remove wrapping tests in "test_that" to reduce duplication. (AA)
 #
 
+library(nloptr)
+
 # f(x) = x1^2 + x2^2
 eval_f <- function(x) {
   list("objective" = x[1] ^ 2 + x[2] ^ 2,

--- a/inst/tinytest/test-hs071.R
+++ b/inst/tinytest/test-hs071.R
@@ -31,6 +31,8 @@
 #   2023-02-07: Remove wrapping tests in "test_that" to reduce duplication. (AA)
 #
 
+library(nloptr)
+
 # f(x) = x1*x4*(x1 + x2 + x3) + x3
 eval_f <- function(x) {
   list("objective" = x[1] * x[4] * (x[1] + x[2] + x[3]) + x[3],

--- a/inst/tinytest/test-is.nloptr.R
+++ b/inst/tinytest/test-is.nloptr.R
@@ -10,6 +10,8 @@
 # Changelog:
 #
 
+library(nloptr)
+
 ctlNM <- list(algorithm = "NLOPT_LN_NELDERMEAD", xtol_rel = 1e-8)
 ctlLB <- list(algorithm = "NLOPT_LD_LBFGS", xtol_rel = 1e-8)
 

--- a/inst/tinytest/test-nloptions.R
+++ b/inst/tinytest/test-nloptions.R
@@ -10,6 +10,8 @@
 # Changelog:
 #
 
+library(nloptr)
+
 opts <- list(
   stopval = -Inf,            # stop minimization at this value
   xtol_rel = 1e-6,           # stop on small optimization step

--- a/inst/tinytest/test-nloptr.R
+++ b/inst/tinytest/test-nloptr.R
@@ -15,6 +15,7 @@
 # weird-looking test. See
 # https://nlopt.readthedocs.io/en/latest/NLopt_Reference/#stopping-criteria
 
+library(nloptr)
 options(digits=7)
 
 tol <- sqrt(.Machine$double.eps)

--- a/inst/tinytest/test-nloptr.add.default.options.R
+++ b/inst/tinytest/test-nloptr.add.default.options.R
@@ -10,6 +10,8 @@
 # Changelog:
 #
 
+library(nloptr)
+
 fn <- function(x) x ^ 2 - 4 * x + 4
 
 expect_warning(nloptr(3, fn, opts = list(algorithm = "NLOPT_LN_NELDERMEAD")),

--- a/inst/tinytest/test-nloptr.print.options.R
+++ b/inst/tinytest/test-nloptr.print.options.R
@@ -12,6 +12,8 @@
 #               Converted the others to tinytest format.
 #
 
+library(nloptr)
+
 expect_stdout(nloptr.print.options(opts.show = "check_derivatives"),
               "user-supplied analytic gradients with finite difference",
               fixed = TRUE)

--- a/inst/tinytest/test-options-maxtime.R
+++ b/inst/tinytest/test-options-maxtime.R
@@ -14,6 +14,8 @@
 #   2019-12-12: Corrected warnings and using updated testtthat framework (AA)
 #   2023-02-07: Remove wrapping tests in "test_that" to reduce duplication. (AA)
 
+library(nloptr)
+
 # Test that solver stops when maxtime is reached.
 # Objective function with sleep added such that maxtime will be reached when
 # solving the optimization problem.

--- a/inst/tinytest/test-parameters.R
+++ b/inst/tinytest/test-parameters.R
@@ -17,6 +17,8 @@
 #   2023-02-07: Remove wrapping tests in "test_that" to reduce duplication. (AA)
 #
 
+library(nloptr)
+
 # Test simple polyonmial where parameters are supplied as additional data.
 
 # Objective function and gradient in terms of parameters.

--- a/inst/tinytest/test-print.nloptr.R
+++ b/inst/tinytest/test-print.nloptr.R
@@ -11,6 +11,7 @@
 #   2023-08-23: Convert _output to _stdout for tinytest
 #
 
+library(nloptr)
 options(digits=7)
 
 x0 <- c(3, 3)

--- a/inst/tinytest/test-simple.R
+++ b/inst/tinytest/test-simple.R
@@ -22,6 +22,8 @@
 #   2023-02-07: Remove wrapping tests in "test_that" to reduce duplication. (AA)
 #
 
+library(nloptr)
+
 tol <- sqrt(.Machine$double.eps)
 
 # Test simple constrained optimization problem with gradient information.

--- a/inst/tinytest/test-systemofeq.R
+++ b/inst/tinytest/test-systemofeq.R
@@ -20,6 +20,8 @@
 #   2019-12-12: Corrected warnings and using updated testtthat framework (AA)
 #   2023-02-07: Remove wrapping tests in "test_that" to reduce duplication. (AA)
 
+library(nloptr)
+
 tol <- sqrt(.Machine$double.eps)
 
 # Test Solve system of equations using NLOPT_LD_MMA with local optimizer

--- a/inst/tinytest/test-wrapper-auglag.R
+++ b/inst/tinytest/test-wrapper-auglag.R
@@ -11,6 +11,8 @@
 #   2023-08-23: Change _output to _stdout
 #
 
+library(nloptr)
+
 ineqMess <- paste("For consistency with the rest of the package the inequality",
                   "sign may be switched from >= to <= in a future nloptr",
                   "version.")

--- a/inst/tinytest/test-wrapper-ccsaq.R
+++ b/inst/tinytest/test-wrapper-ccsaq.R
@@ -11,6 +11,8 @@
 #   2023-08-23: Change _output to _stdout
 #
 
+library(nloptr)
+
 ineqMess <- paste("For consistency with the rest of the package the inequality",
                   "sign may be switched from >= to <= in a future nloptr",
                   "version.")

--- a/inst/tinytest/test-wrapper-cobyla.R
+++ b/inst/tinytest/test-wrapper-cobyla.R
@@ -11,6 +11,8 @@
 #   2023-08-23: Change _output to _stdout
 #
 
+library(nloptr)
+
 ineqMess <- paste("For consistency with the rest of the package the inequality",
                   "sign may be switched from >= to <= in a future nloptr",
                   "version.")

--- a/inst/tinytest/test-wrapper-direct.R
+++ b/inst/tinytest/test-wrapper-direct.R
@@ -11,6 +11,8 @@
 #   2023-08-23: Change _output to _stdout
 #
 
+library(nloptr)
+
 # DirectL is not identical when calling randomized = TRUE. May be an issue with
 # the randomization at the C level. For now, need to pass this tolerance for it
 # to work.

--- a/inst/tinytest/test-wrapper-global.R
+++ b/inst/tinytest/test-wrapper-global.R
@@ -12,6 +12,8 @@
 #   2023-08-23: Change _output to _stdout
 #
 
+library(nloptr)
+
 ineqMess <- paste("For consistency with the rest of the package the inequality",
                   "sign may be switched from >= to <= in a future nloptr",
                   "version.")

--- a/inst/tinytest/test-wrapper-lbgfs.R
+++ b/inst/tinytest/test-wrapper-lbgfs.R
@@ -11,6 +11,8 @@
 #   2023-08-23: Change _output to _stdout
 #
 
+library(nloptr)
+
 ## Functions for the algorithms
 flb <- function(x) {
   p <- length(x)

--- a/inst/tinytest/test-wrapper-mlsl.R
+++ b/inst/tinytest/test-wrapper-mlsl.R
@@ -11,6 +11,8 @@
 #   2023-08-23: Change _stdout to _stdout and _lte to _true
 #
 
+library(nloptr)
+
 tol <- 8e-8
 
 ## Functions for the algorithms

--- a/inst/tinytest/test-wrapper-mma.R
+++ b/inst/tinytest/test-wrapper-mma.R
@@ -11,6 +11,8 @@
 #   2023-08-23: Change _output to _stdout
 #
 
+library(nloptr)
+
 ineqMess <- paste("For consistency with the rest of the package the inequality",
                   "sign may be switched from >= to <= in a future nloptr",
                   "version.")

--- a/inst/tinytest/test-wrapper-nm.R
+++ b/inst/tinytest/test-wrapper-nm.R
@@ -11,6 +11,8 @@
 #   2023-08-23: Change _output to _stdout
 #
 
+library(nloptr)
+
 ## Functions for the algorithms
 fphv <- function(x) {
   100 * (x[3L] - 10 * atan2(x[2L], x[1L]) / (2 * pi)) ^ 2 +

--- a/inst/tinytest/test-wrapper-slsqp.R
+++ b/inst/tinytest/test-wrapper-slsqp.R
@@ -11,6 +11,8 @@
 #   2023-08-23: Change _output to _stdout
 #
 
+library(nloptr)
+
 tol <- sqrt(.Machine$double.eps)
 
 ineqMess <- paste("For consistency with the rest of the package the inequality",

--- a/inst/tinytest/test-wrapper-tnewton.R
+++ b/inst/tinytest/test-wrapper-tnewton.R
@@ -11,6 +11,8 @@
 #   2023-08-23: Change _output to _stdout
 #
 
+library(nloptr)
+
 ## Functions for the algorithms
 flb <- function(x) {
   p <- length(x)

--- a/inst/tinytest/test-wrapper-varmetric.R
+++ b/inst/tinytest/test-wrapper-varmetric.R
@@ -11,6 +11,8 @@
 #   2023-08-23: Change _output to _stdout
 #
 
+library(nloptr)
+
 ## Functions for the algorithms
 flb <- function(x) {
   p <- length(x)


### PR DESCRIPTION
As discussed in #139, adding `library(nloptr)` makes it easier / possible to run test files in isolation which can be helpful in developing and debugging them.