### PR TITLE
Set a default for NCORES

### DIFF
--- a/tools/cmake_call.sh
+++ b/tools/cmake_call.sh
@@ -36,7 +36,7 @@ ${CMAKE_BIN} \
   -D NLOPT_SWIG=OFF \
   -D NLOPT_TESTS=OFF \
   ${CMAKE_ADD_AR} ${CMAKE_ADD_RANLIB} ../nlopt-src
-make -j${NCORES}
+make -j${NCORES:-1}
 make install
 cd ..
 mv nlopt/lib* nlopt/lib


### PR DESCRIPTION
I see a bunch of warnings when configuring:

```
-- Build files have been written to: /tmp/RtmpjkUDAr/file1c4d6c6cb7/nloptr/src/nlopt-build
make: the '-j' option requires a positive integer argument
Usage: make [options] [target] ...
```

The issue is that when NCORES Is unset, the argument is incomplete. This sets a default if NCORES is unset to `1`.