### PR TITLE
Deal with NA returns from detectCores

### DIFF
--- a/tools/cmake_call.sh
+++ b/tools/cmake_call.sh
@@ -2,7 +2,7 @@
 
 : ${R_HOME=$(R RHOME)}
 RSCRIPT_BIN=${R_HOME}/bin/Rscript
-NCORES=`${RSCRIPT_BIN} -e "cat(min(2, parallel::detectCores(logical = FALSE)))"`
+NCORES=`${RSCRIPT_BIN} -e "cat(min(2, parallel::detectCores(logical = FALSE), na.rm=TRUE))"`
 
 cd src
 


### PR DESCRIPTION
parallel::detectCores() may return NA in cases that it fails to guess. In those cases we want to use the default.

```r
> min(2,NA)
# [1] NA
> min(2,NA, na.rm=TRUE)
#  [1] 2
```