### PR TITLE
Add propagation of extra arguments to inequality constraints

### DIFF
--- a/R/auglag.R
+++ b/R/auglag.R
@@ -196,7 +196,7 @@ auglag <- function(x0, fn, gr = NULL, lower = NULL, upper = NULL, hin = NULL,
               "restate the inequality to be <=0. The ability to use the old ",
               "behavior will be removed in a future release.")
       .hin <- match.fun(hin)
-      hin <- function(x) -.hin(x)      # change  hin >= 0  to  hin <= 0 !
+      hin <- function(x) -.hin(x, ...)      # change  hin >= 0  to  hin <= 0 !
     }
   }
   if (!dfree) {

--- a/R/ccsaq.R
+++ b/R/ccsaq.R
@@ -133,7 +133,7 @@ ccsaq <- function(x0, fn, gr = NULL, lower = NULL, upper = NULL, hin = NULL,
               "restate the inequality to be <=0. The ability to use the old ",
               "behavior will be removed in a future release.")
       .hin <- match.fun(hin)
-      hin <- function(x) -.hin(x)      # change  hin >= 0  to  hin <= 0 !
+      hin <- function(x) -.hin(x, ...)      # change  hin >= 0  to  hin <= 0 !
     }
     if (is.null(hinjac)) {
       hinjac <- function(x) nl.jacobian(x, hin)

--- a/R/cobyla.R
+++ b/R/cobyla.R
@@ -109,7 +109,7 @@ cobyla <- function(x0, fn, lower = NULL, upper = NULL, hin = NULL,
               "restate the inequality to be <=0. The ability to use the old ",
               "behavior will be removed in a future release.")
       .hin <- match.fun(hin)
-      hin <- function(x) -.hin(x)      # change  hin >= 0  to  hin <= 0 !
+      hin <- function(x) -.hin(x, ...)      # change  hin >= 0  to  hin <= 0 !
     }
   }
 

--- a/R/global.R
+++ b/R/global.R
@@ -201,7 +201,7 @@ isres <- function(x0, fn, lower, upper, hin = NULL, heq = NULL, maxeval = 10000,
               "restate the inequality to be <=0. The ability to use the old ",
               "behavior will be removed in a future release.")
       .hin <- match.fun(hin)
-      hin <- function(x) -.hin(x)      # change  hin >= 0  to  hin <= 0 !
+      hin <- function(x) -.hin(x, ...)      # change  hin >= 0  to  hin <= 0 !
     }
   }
 

--- a/R/mma.R
+++ b/R/mma.R
@@ -142,7 +142,7 @@ mma <- function(x0, fn, gr = NULL, lower = NULL, upper = NULL, hin = NULL,
               "restate the inequality to be <=0. The ability to use the old ",
               "behavior will be removed in a future release.")
       .hin <- match.fun(hin)
-      hin <- function(x) -.hin(x)      # change  hin >= 0  to  hin <= 0 !
+      hin <- function(x) -.hin(x, ...)      # change  hin >= 0  to  hin <= 0 !
     }
     if (is.null(hinjac)) {
       hinjac <- function(x) nl.jacobian(x, hin)

--- a/R/slsqp.R
+++ b/R/slsqp.R
@@ -127,7 +127,7 @@ slsqp <- function(x0, fn, gr = NULL, lower = NULL, upper = NULL, hin = NULL,
               "restate the inequality to be <=0. The ability to use the old ",
               "behavior will be removed in a future release.")
       .hin <- match.fun(hin)
-      hin <- function(x) -.hin(x)      # change  hin >= 0  to  hin <= 0 !
+      hin <- function(x) -.hin(x, ...)      # change  hin >= 0  to  hin <= 0 !
     }
 
     if (is.null(hinjac)) {


### PR DESCRIPTION
 when using deprecated behavior. Closes #159.