### PR TITLE
Update artifact action to v4

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Upload test results
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-test-failures
           path: ${{ runner.temp }}/package


### PR DESCRIPTION
GitHub emailed that 'artifact' actions v3 would be EOL real soon. When `grep`ing among my repos I noticed this one had a v3 too so here is a quick and hopefully uncontroversial PR to update this.