### PR TITLE
allow ... in objective function signature

### DIFF
--- a/R/nloptr.R
+++ b/R/nloptr.R
@@ -332,6 +332,7 @@ nloptr <- function(x0,
     flist <- formals(fun)
     if (length(flist) > 1) {
       fnms <- names(flist)[2:length(flist)] # remove first argument (x)
+      fnms <- setdiff(fnms, "...") # don't check for '...' argument
       rnms <- names(arglist)
       m1 <- match(fnms, rnms)
       if (anyNA(m1)) {

--- a/inst/tinytest/test-nloptr.R
+++ b/inst/tinytest/test-nloptr.R
@@ -51,6 +51,12 @@ expect_error(nloptr(3, fn, b = "X", c = "Y", d = "Q"),
 expect_warning(nloptr(3, fn, b = 3, c = 4, opts = ctlNM),
                "Skipping derivative checker because algorithm", fixed = TRUE)
 
+fn <- function(x, ...) x^2
+gr <- function(x, ...) 2*x
+expect_equal(nloptr(3, fn, gr,
+       opts = list(algorithm = "NLOPT_LD_LBFGS",
+                   xtol_rel = 1e-4))$status, 1L)
+
 ########################## Tests for nloptr.c ##################################
 ctl <- list(xtol_rel = 1e-8, maxeval = 1000L)
 fn <- function(x) x ^ 2 - 4 * x + 4


### PR DESCRIPTION
This is a duplicate of https://github.com/astamm/nloptr/pull/102, I had forgotten it existed ... but it's minimal (one line of code), and maybe it will avoid the issues that PR had ...

In general the internal `.checkfunargs` function will be unhappy if the objective and/or gradient functions have `...` arguments, e.g.

```r
library(nloptr)
fn <- function(x, ...) x^2
gr <- function(x, ...) 2*x
try(nloptr(3, fn, gr,
       opts = list(algorithm = "NLOPT_LD_LBFGS",
                   xtol_rel = 1e-4))
```

> Error in .checkfunargs(eval_f, arglist, "eval_f") : 
  eval_f requires argument '...' but this has not been passed to the 'nloptr' function.

I find this conflicts with my use case, this pull request allows `...` to be exempt from the general checking function.


